### PR TITLE
tests: use `cabal-doctest` to run `doctest`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -193,7 +193,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "panagia-doctest"

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,5 +1,7 @@
 Hlint: True
 
+Haddock-Components: libs
+
 Raw-Project
   Package panagia
     Flags: +werror +test-doctest

--- a/panagia.cabal
+++ b/panagia.cabal
@@ -1,5 +1,5 @@
 cabal-version:   3.0
-build-type:      Simple
+build-type:      Custom
 name:            panagia
 version:         0.0.1.0
 synopsis:        An island close to Paxos
@@ -17,6 +17,12 @@ category:        Network
 stability:       Experimental
 extra-doc-files: CHANGELOG.md
 tested-with:     GHC ==9.4.3
+
+custom-setup
+  setup-depends:
+    , base           ^>=4.17.0.0
+    , Cabal          ^>=3.6.3.0  || ^>=3.8.1.0
+    , cabal-doctest  ^>=1.0.9
 
 source-repository head
   type:     git
@@ -93,7 +99,8 @@ benchmark panagia-bench
     , panagia
 
 test-suite panagia-doctest
-  import:           warnings
+  import:               warnings
+  x-doctest-components: lib
 
   if flag(test-doctest)
     buildable: True
@@ -101,10 +108,18 @@ test-suite panagia-doctest
   else
     buildable: False
 
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   test
-  default-language: Haskell2010
-  main-is:          panagia-doctest.hs
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  default-language:     Haskell2010
+  main-is:              panagia-doctest.hs
+  other-modules:        Build_doctests
+  autogen-modules:      Build_doctests
+
+  -- Disable warnings triggered by the (generated) 'Build_doctests' module
+  ghc-options:          -Wno-missing-export-lists
   build-depends:
-    , base     ^>=4.17.0.0
-    , doctest  ^>=0.20.1
+    , base              ^>=4.17.0.0
+    , doctest           ^>=0.20.1
+    , panagia
+    , QuickCheck        ^>=2.14.2
+    , template-haskell  ^>=2.19.0.0

--- a/test/panagia-doctest.hs
+++ b/test/panagia-doctest.hs
@@ -1,6 +1,20 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Main (main) where
 
+import Build_doctests (Component (..), Name (..), components)
+import Data.Foldable (for_)
+import Data.Maybe (fromMaybe)
+import System.Environment (unsetEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
-main = doctest ["src/"]
+main = for_ components $ \(Component name flags pkgs sources) -> do
+  putStrLn $ "Running doctests for " <> showName name
+  let args = flags ++ pkgs ++ sources
+  unsetEnv "GHC_ENVIRONMENT"
+  doctest args
+  where
+    showName = \case
+      NameLib l -> "lib:" <> fromMaybe "panagia" l
+      NameExe e -> "exe:" <> e


### PR DESCRIPTION
Sadly enough, integrating `doctest` in a Cabal-based project, running the test as a `test-suite`, is not trivial: a whole load of arguments need to be passed to `doctest` for it to find all dependencies, and one needs to ensure `QuickCheck` and `template-haskell` are available when using the `prop>` feature, including `import`in `Test.QuickCheck` in a module under test (e.g., in a `$setup` section).

This patch migrates the previous approach, which worked but doesn't scale once we add more features/dependencies, to use `cabal-doctest` which relies on using the `Custom` `build-type` to generate some module which can then be consumed from a test `Main` module.

Despite this project currently having only a single exposed artifact (i.e., the `panagia` library), the changes made are as-if it's a multi-component project already, to account for future expansion.

See: https://hackage.haskell.org/package/cabal-doctest
See: https://github.com/haskellari/cabal-doctest
See: https://github.com/haskellari/cabal-doctest/tree/44f04e6d7563066e3373675a834ea3bf9c095bfb/multiple-components-example