### PR TITLE
panagia: implement `Learner` functionality

### DIFF
--- a/src/Panagia/Paxos/SingleDecree.hs
+++ b/src/Panagia/Paxos/SingleDecree.hs
@@ -185,7 +185,7 @@ handlePromise state0 sender (promiseBallot, promiseVote) = case state0 of
     EQ -> do
       let votes = Map.insert sender promiseVote votes0
 
-      isQuorum' <- isQuorum (Map.keysSet votes)
+      isQuorum' <- isProposerQuorum (Map.keysSet votes)
       if isQuorum'
         then do
           let v = maybe value snd (maximumBy (fmap fst) Nothing votes)

--- a/src/Panagia/Paxos/SingleDecree/Free.hs
+++ b/src/Panagia/Paxos/SingleDecree/Free.hs
@@ -52,8 +52,8 @@ data ProposerF node ballot value a
     BroadcastPrepare (Prepare ballot) a
   | -- | 'broadcastAccept'
     BroadcastAccept (Accept ballot value) a
-  | -- | 'isQuorum'
-    IsQuorum (Set node) (Bool -> a)
+  | -- | 'isProposerQuorum'
+    IsProposerQuorum (Set node) (Bool -> a)
   deriving (Functor)
 
 instance MonadProposer (Free (ProposerF node ballot value)) where
@@ -64,7 +64,7 @@ instance MonadProposer (Free (ProposerF node ballot value)) where
   newBallot = liftF $ NewBallot id
   broadcastPrepare b = liftF $ BroadcastPrepare b ()
   broadcastAccept msg = liftF $ BroadcastAccept msg ()
-  isQuorum s = liftF $ IsQuorum s id
+  isProposerQuorum s = liftF $ IsProposerQuorum s id
 
 instance (Monad m) => MonadProposer (FreeT (ProposerF node ballot value) m) where
   type ProposerAcceptorNode (FreeT (ProposerF node ballot value) m) = node
@@ -74,7 +74,7 @@ instance (Monad m) => MonadProposer (FreeT (ProposerF node ballot value) m) wher
   newBallot = liftF $ NewBallot id
   broadcastPrepare b = liftF $ BroadcastPrepare b ()
   broadcastAccept msg = liftF $ BroadcastAccept msg ()
-  isQuorum s = liftF $ IsQuorum s id
+  isProposerQuorum s = liftF $ IsProposerQuorum s id
 
 -- | A functor representing 'MonadAcceptorTransaction' actions.
 --

--- a/src/Panagia/Paxos/SingleDecree/Monad.hs
+++ b/src/Panagia/Paxos/SingleDecree/Monad.hs
@@ -19,6 +19,7 @@ module Panagia.Paxos.SingleDecree.Monad
     MonadAcceptor (..),
     MonadAcceptorTransaction (..),
     monadAcceptorLaws,
+    MonadLearner (..),
   )
 where
 
@@ -488,5 +489,74 @@ monadAcceptorLaws genBallot genValue =
             assert $ v' == Just (b, v)
     )
   ]
+
+-- }}}
+
+-- MonadLearner {{{
+
+-- | Monad providing the effects a Learner needs to perform its duties.
+class (Monad m) => MonadLearner m where
+  -- | Type of an acceptor node in the cluster.
+  type LearnerAcceptorNode m
+
+  -- | Check whether a given set of nodes forms a quorum in the cluster.
+  isLearnerQuorum :: Set (LearnerAcceptorNode m) -> m Bool
+  default isLearnerQuorum ::
+    ( MonadLearner n,
+      MonadTrans t,
+      m ~ t n,
+      LearnerAcceptorNode m ~ LearnerAcceptorNode n
+    ) =>
+    Set (LearnerAcceptorNode m) ->
+    m Bool
+  isLearnerQuorum = lift . isLearnerQuorum
+
+instance (MonadLearner m, Monoid w) => MonadLearner (AccumT w m) where
+  type LearnerAcceptorNode (AccumT w m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (ContT r m) where
+  type LearnerAcceptorNode (ContT r m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (ExceptT e m) where
+  type LearnerAcceptorNode (ExceptT e m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (IdentityT m) where
+  type LearnerAcceptorNode (IdentityT m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (MaybeT m) where
+  type LearnerAcceptorNode (MaybeT m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (CPS.RWST r w s m) where
+  type LearnerAcceptorNode (CPS.RWST r w s m) = LearnerAcceptorNode m
+
+instance (MonadLearner m, Monoid w) => MonadLearner (Lazy.RWST r w s m) where
+  type LearnerAcceptorNode (Lazy.RWST r w s m) = LearnerAcceptorNode m
+
+instance (MonadLearner m, Monoid w) => MonadLearner (Strict.RWST r w s m) where
+  type LearnerAcceptorNode (Strict.RWST r w s m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (ReaderT r m) where
+  type LearnerAcceptorNode (ReaderT r m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (SelectT r m) where
+  type LearnerAcceptorNode (SelectT r m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (Lazy.StateT s m) where
+  type LearnerAcceptorNode (Lazy.StateT s m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (Strict.StateT s m) where
+  type LearnerAcceptorNode (Strict.StateT s m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (CPS.WriterT w m) where
+  type LearnerAcceptorNode (CPS.WriterT w m) = LearnerAcceptorNode m
+
+instance (MonadLearner m, Monoid w) => MonadLearner (Lazy.WriterT w m) where
+  type LearnerAcceptorNode (Lazy.WriterT w m) = LearnerAcceptorNode m
+
+instance (MonadLearner m, Monoid w) => MonadLearner (Strict.WriterT w m) where
+  type LearnerAcceptorNode (Strict.WriterT w m) = LearnerAcceptorNode m
+
+instance (MonadLearner m) => MonadLearner (CatchT m) where
+  type LearnerAcceptorNode (CatchT m) = LearnerAcceptorNode m
 
 -- }}}

--- a/src/Panagia/Paxos/SingleDecree/Monad.hs
+++ b/src/Panagia/Paxos/SingleDecree/Monad.hs
@@ -99,8 +99,8 @@ class (Monad m) => MonadProposer m where
   broadcastAccept = lift . broadcastAccept
 
   -- | Check whether a given set of nodes forms a quorum in the cluster.
-  isQuorum :: Set (ProposerAcceptorNode m) -> m Bool
-  default isQuorum ::
+  isProposerQuorum :: Set (ProposerAcceptorNode m) -> m Bool
+  default isProposerQuorum ::
     ( MonadProposer n,
       MonadTrans t,
       m ~ t n,
@@ -108,7 +108,7 @@ class (Monad m) => MonadProposer m where
     ) =>
     Set (ProposerAcceptorNode m) ->
     m Bool
-  isQuorum = lift . isQuorum
+  isProposerQuorum = lift . isProposerQuorum
 
 instance (MonadProposer m, Monoid w) => MonadProposer (AccumT w m) where
   type ProposerAcceptorNode (AccumT w m) = ProposerAcceptorNode m

--- a/test/Panagia/Paxos/SingleDecree/Test.hs
+++ b/test/Panagia/Paxos/SingleDecree/Test.hs
@@ -5,7 +5,7 @@
 
 module Panagia.Paxos.SingleDecree.Test (tests) where
 
-import Control.Lens (at, use, (.=), (^.))
+import Control.Lens (at, use, (^.))
 import Control.Monad ((>=>))
 import Control.Monad.Catch (catch)
 import Data.Maybe (isJust)
@@ -26,11 +26,11 @@ import Panagia.Paxos.SingleDecree.Test.Monad
     handleMessage,
     handleMessages,
     initProposer,
+    resetLearner,
   )
 import qualified Panagia.Paxos.SingleDecree.Test.Monad as M
 import Panagia.Paxos.SingleDecree.Test.Types
   ( Message (Promise),
-    learners,
     messages,
     persistentState,
     proposerBallot,
@@ -81,9 +81,15 @@ consensusRetained = do
     handleMessages pickMessage
     consensusReached learner `shouldReturn` Just 1
 
+    resetLearner learner
+    consensusReached learner `shouldReturn` Nothing
+
     initProposer proposer2 2
     handleMessages pickMessage
     consensusReached learner `shouldReturn` Just 1
+
+    resetLearner learner
+    consensusReached learner `shouldReturn` Nothing
 
     initProposer proposer1 2
     handleMessages pickMessage
@@ -132,7 +138,7 @@ threeProposers pick = property $ do
     -- accepted value should be the one that was accepted earlier, not one
     -- of the 'new' values.
     n <- evalM $ do
-      learners . at learner .= Just mempty
+      resetLearner learner
       consensusReached learner
 
     n === Nothing

--- a/test/Panagia/Paxos/SingleDecree/Test/Monad.hs
+++ b/test/Panagia/Paxos/SingleDecree/Test/Monad.hs
@@ -115,7 +115,7 @@ runProposer thisNode = iterT $ \case
     acceptors' <- view configAcceptors
     tell $ Set.map (\t -> mkSome $ Accept thisNode t m) acceptors'
     next
-  F.IsQuorum s next ->
+  F.IsProposerQuorum s next ->
     next . ($ s) =<< view isQuorum
 
 runAcceptor ::


### PR DESCRIPTION
Similar to how `Proposer` and `Accepted` are implemented, this provides an MTL-style class of effects, and a handler, in this case for `Accepted` messages.
    
This handler takes, similar to `propose`, a `LearnerState`, which *must* be constructed by the caller when the learner starts (using `initLearnerState`). An invocation of `handleAccepted` may then either yield a value, if consensus was reached (and the state can be discarded), or an updated state to be used in a next call to `handleAccepted`.
    
Test-cases are updated accordingly.
 
Closes: https://github.com/NicolasT/panagia/issues/15